### PR TITLE
Additional of 2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ var handleFinish = function () {
 <Countdown targetDate={new Date('August 29, 1997')}
            startDelay={2000}
            interval={1000}
+           timeSeparator={':'}
+           leadingZero
            onFinished={handleFinish} />
 ```
 
@@ -78,6 +80,24 @@ The callback function to be called when the countdown ends.
 
 * type: `Function`
 * optional
+
+### [timeSeparator]
+
+The string used to separate the different parts of the time
+
+* type: `String`
+* optional
+* default: `&nbsp;`
+ 
+### [leadingZero]
+
+Prepends a leading zero onto the time elements for consistant width
+
+* type: `Bool`
+* optional
+* default: 
+ 
+
 
 ## Contribution guide
 

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -96,7 +96,7 @@ export default class Countdown extends Component {
     }
 
     if (this.props.format.second) {
-      lets seconds = time.format(this.props.format.second)
+      let seconds = time.format(this.props.format.second)
       html.push(
         <span className="react-cntdwn-second" key="second">
           {seconds}

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -70,6 +70,9 @@ export default class Countdown extends Component {
 
     if (this.props.format.day) {
       let days = time.format(this.props.format.day)
+      if (this.props.leadingZero) {
+        days = this.addLeadingZero(days)
+      }
       html.push(
         <span className="react-cntdwn-day" key="day">
           {days}&nbsp;
@@ -79,6 +82,9 @@ export default class Countdown extends Component {
 
     if (this.props.format.hour) {
       let hours = time.format(this.props.format.hour)
+      if (this.props.leadingZero) {
+        hours = this.addLeadingZero(hours)
+      }
       html.push(
         <span className="react-cntdwn-hour" key="hour">
           {hours}{timeSeparator}
@@ -88,6 +94,9 @@ export default class Countdown extends Component {
 
     if (this.props.format.minute) {
       let minutes = time.format(this.props.format.minute)
+      if (this.props.leadingZero) {
+        minutes = this.addLeadingZero(minutes)
+      }
       html.push(
         <span className="react-cntdwn-minute" key="minute">
           {minutes}{timeSeparator}
@@ -97,6 +106,9 @@ export default class Countdown extends Component {
 
     if (this.props.format.second) {
       let seconds = time.format(this.props.format.second)
+      if (this.props.leadingZero) {
+        seconds = this.addLeadingZero(seconds)
+      }
       html.push(
         <span className="react-cntdwn-second" key="second">
           {seconds}

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -54,33 +54,37 @@ export default class Countdown extends Component {
     let html = [];
 
     if (this.props.format.day) {
+      let days = time.format(this.props.format.day)
       html.push(
         <span className="react-cntdwn-day" key="day">
-          {time.format(this.props.format.day)}&nbsp;
+          {days}
         </span>
       );
     }
 
     if (this.props.format.hour) {
+      let hours = time.format(this.props.format.hour)
       html.push(
         <span className="react-cntdwn-hour" key="hour">
-          {time.format(this.props.format.hour)}&nbsp;
+          {hours}
         </span>
       );
     }
 
     if (this.props.format.minute) {
+      let minutes = time.format(this.props.format.minute)
       html.push(
         <span className="react-cntdwn-minute" key="minute">
-          {time.format(this.props.format.minute)}&nbsp;
+          {minutes}
         </span>
       );
     }
 
     if (this.props.format.second) {
+      lets seconds = time.format(this.props.format.second)
       html.push(
         <span className="react-cntdwn-second" key="second">
-          {time.format(this.props.format.second)}
+          {seconds}
         </span>
       );
     }

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -35,6 +35,13 @@ export default class Countdown extends Component {
     return moment(this.props.targetDate).diff(moment(now));
   }
 
+  addLeadingZero(value) {
+    if (value.length < 2) {
+      return '0'+value 
+    }
+    return value
+  }
+
   tick() {
     this.setState({remainingTime: this.calculateRemainingTime()});
 
@@ -52,12 +59,20 @@ export default class Countdown extends Component {
   renderRemainingTime() {
     let time = milliSec(this.state.remainingTime);
     let html = [];
+    
+    let timeSeparator;
+    if (this.props.timeSeparator) {
+      timeSeparator = this.props.timeSeparator 
+    } else {
+      timeSeparator = '&nbsp;'
+    }
+    
 
     if (this.props.format.day) {
       let days = time.format(this.props.format.day)
       html.push(
         <span className="react-cntdwn-day" key="day">
-          {days}
+          {days}&nbsp;
         </span>
       );
     }
@@ -66,7 +81,7 @@ export default class Countdown extends Component {
       let hours = time.format(this.props.format.hour)
       html.push(
         <span className="react-cntdwn-hour" key="hour">
-          {hours}
+          {hours}{timeSeparator}
         </span>
       );
     }
@@ -75,7 +90,7 @@ export default class Countdown extends Component {
       let minutes = time.format(this.props.format.minute)
       html.push(
         <span className="react-cntdwn-minute" key="minute">
-          {minutes}
+          {minutes}{timeSeparator}
         </span>
       );
     }


### PR DESCRIPTION
- Allow users to choose the separator of the different time parts
- Allows users to display time with leading zeros ( ie: 9:15:1 then reads as 09:15:01, as a clock normally would )
