### PR TITLE
update to use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "moment": "^2.12.0",
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^15.6.0",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -70,48 +70,65 @@ export default class Countdown extends Component {
 
     if (format.day) {
       let days = moment.duration(remainingTime).get('days')
+
       if (leadingZero) {
         days = this.addLeadingZero(days)
       }
+
+      let output = format.day.replace('dd', days)
+
       html.push(
         <span className='react-cntdwn-day' key='day'>
-          {days}&nbsp;
+          {output}&nbsp;
         </span>
       )
     }
 
     if (format.hour) {
       let hours = moment.duration(remainingTime).get('hours')
+
       if (leadingZero) {
         hours = this.addLeadingZero(hours)
       }
+
+      let output = format.hour.replace('hh', hours)
+
       html.push(
         <span className='react-cntdwn-hour' key='hour'>
-          {hours}{timeSeparator}
+          {output}{timeSeparator}
         </span>
       )
     }
 
     if (format.minute) {
       let minutes = moment.duration(remainingTime).get('minutes')
+
       if (leadingZero) {
         minutes = this.addLeadingZero(minutes)
+
       }
+
+      let output = format.minute.replace('mm', minutes)
+
       html.push(
         <span className='react-cntdwn-minute' key='minute'>
-          {minutes}{timeSeparator}
+          {output}{timeSeparator}
         </span>
       )
     }
 
     if (format.second) {
       let seconds = moment.duration(remainingTime).get('seconds')
+
       if (leadingZero) {
         seconds = this.addLeadingZero(seconds)
       }
+
+      let output = format.second.replace('ss', seconds)
+
       html.push(
         <span className='react-cntdwn-second' key='second'>
-          {seconds}
+          {output}
         </span>
       )
     }

--- a/src/cntdwn.jsx
+++ b/src/cntdwn.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import moment from 'moment'
 
 const COUNTDOWN_NOT_STARTED = 1


### PR DESCRIPTION
I'm trying to use this package in a new project and I'm running into issues with accessing PropTypes through the React package. This was deprecated a while back.

I think this is all that should be needed but I can't fully test since I am getting a weird build error on my machine.